### PR TITLE
fix bug: DeviceState.get_all_children doesn't return all the children of a view

### DIFF
--- a/droidbot/app.py
+++ b/droidbot/app.py
@@ -26,7 +26,10 @@ class App(object):
                 os.makedirs(output_dir)
 
         # from androguard.core.bytecodes.apk import APK
-        from androguard.core.apk import APK
+        try:
+            from androguard.core.bytecodes.apk import APK
+        except ImportError:
+            from androguard.core.apk import APK
         self.apk = APK(self.app_path)
         self.package_name = self.apk.get_package()
         self.app_name = self.apk.get_app_name()

--- a/droidbot/device.py
+++ b/droidbot/device.py
@@ -508,7 +508,7 @@ class Device(object):
         Get current activity
         """
         r = self.adb.shell("dumpsys activity activities")
-        activity_line_re = re.compile('\* Hist #\d+: ActivityRecord{[^ ]+ [^ ]+ ([^ ]+) t(\d+)}')
+        activity_line_re = re.compile(r'\*\s*Hist\s*#\d+:\s*ActivityRecord\{[^ ]+\s*[^ ]+\s*([^ ]+)\s*t(\d+)}')
         m = activity_line_re.search(r)
         if m:
             return m.group(1)
@@ -545,14 +545,19 @@ class Device(object):
         task_to_activities = {}
 
         lines = self.adb.shell("dumpsys activity activities").splitlines()
-        activity_line_re = re.compile('\* Hist #\d+: ActivityRecord{[^ ]+ [^ ]+ ([^ ]+) t(\d+)}')
+        activity_line_re = re.compile(r'\*\s*Hist\s*#\d+:\s*ActivityRecord\{[^ ]+\s*[^ ]+\s*([^ ]+)\s*t(\d+)}')
 
         for line in lines:
             line = line.strip()
-            if line.startswith("Task id #"):
-                task_id = line[9:]
+            activity_line_task_re = re.compile(r'^\s*Task\s*id\s*#(\d+)|^\s*Task\{\w+\s*#(\d+)')
+            activity_line_task_m = activity_line_task_re.match(line)
+            if activity_line_task_m:
+                if activity_line_task_m.group(1):
+                    task_id = activity_line_task_m.group(1)
+                else:
+                    task_id = activity_line_task_m.group(2)
                 task_to_activities[task_id] = []
-            elif line.startswith("* Hist #"):
+            elif re.match(r'\*\s*Hist\s*#', line):
                 m = activity_line_re.match(line)
                 if m:
                     activity = m.group(1)

--- a/droidbot/device.py
+++ b/droidbot/device.py
@@ -95,6 +95,10 @@ class Device(object):
         if self.is_emulator:
             self.logger.info("disable minicap on emulator")
             self.adapters[self.minicap] = False
+        # minicap is not supporting android 32 and above
+        if self.get_sdk_version() >= 32:
+            self.logger.info("disable minicap on sdk >= 32")
+            self.adapters[self.minicap] = False
 
     def check_connectivity(self):
         """

--- a/droidbot/device_state.py
+++ b/droidbot/device_state.py
@@ -417,7 +417,7 @@ class DeviceState(object):
         children = set(children)
         for child in children:
             children_of_child = self.get_all_children(self.views[child])
-            children.union(children_of_child)
+            children = children.union(children_of_child)
         return children
 
     def get_app_activity_depth(self, app):

--- a/droidbot/device_state.py
+++ b/droidbot/device_state.py
@@ -42,7 +42,7 @@ class DeviceState(object):
         self.possible_events = None
         self.width = device.get_width(refresh=True)
         self.height = device.get_height(refresh=False)
-        self._save_important_view_ids()
+        # self._save_important_view_ids()
         
 
     @property

--- a/droidbot/input_event.py
+++ b/droidbot/input_event.py
@@ -444,7 +444,8 @@ class UIEvent(InputEvent):
         view_text = view['text'].replace('\n', '\\n') if 'text' in view and view['text'] else ''
         view_text = view_text[:10] if len(view_text) > 10 else view_text
         view_short_sig = f'{state.activity_short_name}/{view_class}-{view_text}'
-        return f"state={state.state_str}, view={view['view_str']}({view_short_sig})"
+        safe_get = lambda d, k, default: d[k] if k in d else default
+        return f"state={state.state_str}, view={safe_get(view, "view_str", "default_str")}({view_short_sig})"
 
 
 class TouchEvent(UIEvent):


### PR DESCRIPTION
```cmd
>>> a = set([1, 2, 3])
>>> b = set([2, 3, 4])
>>> a.union(b)
{1, 2, 3, 4}
>>> a
{1, 2, 3}
>>> a = a.union(b)
>>> a
{1, 2, 3, 4}
```
A set won't be update after set.union(set) called.